### PR TITLE
Support scrolling when modal is tall

### DIFF
--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -1,6 +1,6 @@
 <template>
   <portal to="modals">
-    <div v-if="showModal" class="fixed inset-0 overflow-y-auto">
+    <div v-if="showModal" class="fixed inset-0">
       <transition
         @before-leave="backdropLeaving = true"
         @after-leave="backdropLeaving = false"
@@ -13,7 +13,7 @@
         appear
       >
         <div v-if="showBackdrop">
-          <div class="fixed inset-0 bg-black opacity-25" @click="close"></div>
+          <div class="fixed inset-0 bg-black opacity-25"></div>
         </div>
       </transition>
 
@@ -28,9 +28,9 @@
         leave-to-class="opacity-0 scale-70"
         appear
       >
-        <div v-if="showContent" class="relative text-center">
+        <div v-if="showContent" class="relative h-full overflow-y-auto text-center" @click="close">
           <div class="inline-block align-middle w-0 h-screen"></div>
-          <div class="inline-block align-middle text-left my-6">
+          <div class="inline-block align-middle text-left my-6" @click.stop>
             <slot></slot>
           </div>
         </div>
@@ -92,10 +92,12 @@ export default {
       this.showModal = true
       this.showBackdrop = true
       this.showContent = true
+      document.body.style.setProperty('overflow', 'hidden')
     },
     close() {
       this.showBackdrop = false
       this.showContent = false
+      document.body.style.removeProperty('overflow')
     }
   }
 }

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -1,6 +1,6 @@
 <template>
   <portal to="modals">
-    <div v-if="showModal" class="fixed inset-0 flex items-center justify-center">
+    <div v-if="showModal" class="fixed inset-0 overflow-y-auto">
       <transition
         @before-leave="backdropLeaving = true"
         @after-leave="backdropLeaving = false"
@@ -13,7 +13,7 @@
         appear
       >
         <div v-if="showBackdrop">
-          <div class="absolute inset-0 bg-black opacity-25" @click="close"></div>
+          <div class="fixed inset-0 bg-black opacity-25" @click="close"></div>
         </div>
       </transition>
 
@@ -28,8 +28,11 @@
         leave-to-class="opacity-0 scale-70"
         appear
       >
-        <div v-if="showContent" class="relative">
-          <slot></slot>
+        <div v-if="showContent" class="relative text-center">
+          <div class="inline-block align-middle w-0 h-screen"></div>
+          <div class="inline-block align-middle text-left my-6">
+            <slot></slot>
+          </div>
         </div>
       </transition>
     </div>


### PR DESCRIPTION
This was pretty damn hard to figure out but Netlify had a good (albeit also awful but that's not their fault, it's the web's) solution.

Basically the challenge is how do you make a modal perfectly centered when there's room, but have the modal area scroll if the modal is too tall?

The solution ends up being using `inline-block` for the modal itself and putting it next to an extra element that's also `inline-block` and has a height of `100vh` but `width: 0`, and making them both `vertical-align: middle`. You don't need flexbox to do the centering at all using this approach but the whole thing definitely feels terrifying.

Check out the deploy preview and test it out and let me know if I missed anything!